### PR TITLE
Fixing broken links to trained models for Jam Session JS

### DIFF
--- a/ai-jam-js/README.md
+++ b/ai-jam-js/README.md
@@ -24,10 +24,10 @@ sh RUN_DEMO.sh
 
 When the script is run, the following pre-trained models will be automatically downloaded to the ai-jam-js directory:
 
-* [Attention RNN](/magenta/models/melody_rnn/README.md#attention)
-* [Pianoroll RNN-NADE](/magenta/models/pianoroll_rnn_nade/README.md)
-* [Performance RNN](/magenta/models/performance_rnn/README.md)
-* [Drum Kit RNN](/magenta/models/drums_rnn/README.md)
+* [Attention RNN](https://github.com/tensorflow/magenta/tree/master/magenta/models/melody_rnn/README.md#attention)
+* [Pianoroll RNN-NADE](https://github.com/tensorflow/magenta/tree/master/magenta/models/pianoroll_rnn_nade/README.md)
+* [Performance RNN](https://github.com/tensorflow/magenta/tree/master/magenta/models/performance_rnn/README.md)
+* [Drum Kit RNN](https://github.com/tensorflow/magenta/tree/master/magenta/models/drums_rnn/README.md)
 
 ### Development
 

--- a/ai-jam-js/README.md
+++ b/ai-jam-js/README.md
@@ -24,7 +24,8 @@ sh RUN_DEMO.sh
 
 When the script is run, the following pre-trained models will be automatically downloaded to the ai-jam-js directory:
 
-* [Attention RNN](/magenta/models/melody_rnn/README.md#attention)
+* [Attention RNN](/magenta-demos)
+/models/melody_rnn/README.md#attention)
 * [Pianoroll RNN-NADE](/magenta/models/pianoroll_rnn_nade/README.md)
 * [Performance RNN](/magenta/models/performance_rnn/README.md)
 * [Drum Kit RNN](/magenta/models/drums_rnn/README.md)

--- a/ai-jam-js/README.md
+++ b/ai-jam-js/README.md
@@ -24,7 +24,7 @@ sh RUN_DEMO.sh
 
 When the script is run, the following pre-trained models will be automatically downloaded to the ai-jam-js directory:
 
-* [Attention RNN](tensorflow/magenta/models/melody_rnn/README.md#attention)
+* [Attention RNN](/magenta/models/melody_rnn/README.md#attention)
 * [Pianoroll RNN-NADE](/magenta/models/pianoroll_rnn_nade/README.md)
 * [Performance RNN](/magenta/models/performance_rnn/README.md)
 * [Drum Kit RNN](/magenta/models/drums_rnn/README.md)

--- a/ai-jam-js/README.md
+++ b/ai-jam-js/README.md
@@ -24,8 +24,7 @@ sh RUN_DEMO.sh
 
 When the script is run, the following pre-trained models will be automatically downloaded to the ai-jam-js directory:
 
-* [Attention RNN](magenta-demos/README.md)
-/models/melody_rnn/README.md#attention)
+* [Attention RNN](/magenta/models/melody_rnn/README.md#attention)
 * [Pianoroll RNN-NADE](/magenta/models/pianoroll_rnn_nade/README.md)
 * [Performance RNN](/magenta/models/performance_rnn/README.md)
 * [Drum Kit RNN](/magenta/models/drums_rnn/README.md)

--- a/ai-jam-js/README.md
+++ b/ai-jam-js/README.md
@@ -24,7 +24,7 @@ sh RUN_DEMO.sh
 
 When the script is run, the following pre-trained models will be automatically downloaded to the ai-jam-js directory:
 
-* [Attention RNN](magenta/models/melody_rnn/README.md#attention)
+* [Attention RNN](tensorflow/magenta/models/melody_rnn/README.md#attention)
 * [Pianoroll RNN-NADE](/magenta/models/pianoroll_rnn_nade/README.md)
 * [Performance RNN](/magenta/models/performance_rnn/README.md)
 * [Drum Kit RNN](/magenta/models/drums_rnn/README.md)

--- a/ai-jam-js/README.md
+++ b/ai-jam-js/README.md
@@ -24,7 +24,7 @@ sh RUN_DEMO.sh
 
 When the script is run, the following pre-trained models will be automatically downloaded to the ai-jam-js directory:
 
-* [Attention RNN](/magenta/models/melody_rnn/README.md#attention)
+* [Attention RNN](magenta/models/melody_rnn/README.md#attention)
 * [Pianoroll RNN-NADE](/magenta/models/pianoroll_rnn_nade/README.md)
 * [Performance RNN](/magenta/models/performance_rnn/README.md)
 * [Drum Kit RNN](/magenta/models/drums_rnn/README.md)

--- a/ai-jam-js/README.md
+++ b/ai-jam-js/README.md
@@ -24,7 +24,7 @@ sh RUN_DEMO.sh
 
 When the script is run, the following pre-trained models will be automatically downloaded to the ai-jam-js directory:
 
-* [Attention RNN](/magenta-demos)
+* [Attention RNN](magenta-demos/README.md)
 /models/melody_rnn/README.md#attention)
 * [Pianoroll RNN-NADE](/magenta/models/pianoroll_rnn_nade/README.md)
 * [Performance RNN](/magenta/models/performance_rnn/README.md)


### PR DESCRIPTION
I wasn't sure how to do relative links, since the models are documented in the magenta repo, while this is the magenta-demos repo. Using absolute links.