### PR TITLE
Use print() function in both Python 2 and Python 3

### DIFF
--- a/ai-jam-js/maybe_download_mags.py
+++ b/ai-jam-js/maybe_download_mags.py
@@ -1,5 +1,9 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
 import os
-import urllib
+from six.moves.urllib.request import URLopener
 
 # This script downloads these .mag files if not already present.
 mag_files = [
@@ -15,5 +19,5 @@ for mag_file in mag_files:
     print('File %s already present' % mag_file)
   else:
     print('Writing %s to %s' % (mag_file, output_file))
-    urlopener = urllib.URLopener()
+    urlopener = URLopener()
     urlopener.retrieve(mag_file, output_file)

--- a/ai-jam-js/maybe_download_mags.py
+++ b/ai-jam-js/maybe_download_mags.py
@@ -12,8 +12,8 @@ mag_files = [
 for mag_file in mag_files:
   output_file = mag_file.split('/')[-1]
   if os.path.exists(output_file):
-    print 'File %s already present' % mag_file
+    print('File %s already present' % mag_file)
   else:
-    print 'Writing %s to %s' % (mag_file, output_file)
+    print('Writing %s to %s' % (mag_file, output_file))
     urlopener = urllib.URLopener()
     urlopener.retrieve(mag_file, output_file)


### PR DESCRIPTION
Python 3 treats legacy __print__ statements as syntax errors but __print()__ function works as expected in both Python 2 and Python 3.