### PR TITLE
NSynth MaxForLive plugin grid generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.DS_Store
+nsynth/audio_input
+nsynth/output_grids
+nsynth/working_dir

--- a/nsynth/README.md
+++ b/nsynth/README.md
@@ -20,11 +20,11 @@ By following this guide, you will be able to prepare audio samples in WAV/AIF fo
 A fast computer is required to produce audio in a reasonable amount of time; however it is possible to speed up the process by simplifying the task. The variables are:
 
 - Batch size (per process)
-- Number of interpolation combinations
+- Number of instruments
 - Number of example pitches
 - Grid resolution
 
-As an example, a complex interpolation task (e.g. to produce the sounds for the default settings.json in this repository, the source audio for generating this multigrid is available [here](https://storage.googleapis.com/open-nsynth-super/audio/onss_source_audio.tar.gz)) includes 16 different instruments, a 9x9 grid resolution (between every set of 4 instruments), and 16 example pitches. This task takes around 9 hours on a GTX 1080 Ti and will generate 10000 audio files total.
+As an example, a complex interpolation task including 16 different instruments, a 9x9 grid resolution, and 16 example pitches takes around 9 hours on a GTX 1080 Ti and will generate 10000 audio files total. The default settings.json in this repository will generate a multigrid (4 grids in one) with these properties (source audio is available [here](https://storage.googleapis.com/open-nsynth-super/audio/onss_source_audio.tar.gz)).
 
 You will need a Unix-like PC or server with at least one CUDA-compatible GPU and magenta, sox, and lame installed.
 
@@ -51,7 +51,7 @@ According to the default settings, these files should be created at the followin
 - 84 (C7)
 
 
-For instruments that are out of range at any of these pitches, you can pitch down or up using software, or repeat the nearest ‘available’ pitch to fill in the gaps. Alternatively, for unpitched sounds like drums you can maintain a single pitch across all notes, or pitch each one manually.
+For instruments that are out of range at any of these pitches, you can pitch down or up using software, or repeat the nearest "available" pitch to fill in the gaps. Alternatively, for unpitched sounds like drums you can maintain a single pitch across all notes, or pitch each one manually.
 
 Changing these conditioning values can result in interesting different combinations and is one of the most interesting and powerful ways to alter the behavior of the instrument.
 
@@ -69,7 +69,7 @@ guitar_28.wav
 ...
 ```
 
-Note that a section of the magenta pipeline (`nsynth_save_embeddings`) sometimes truncates a couple characters from the start of filenames. generate.py should automatically correct this, however, it might "correct" files in unexpected ways if any filenames are substrings of other file names (having `guitar` and `acoustic_guitar` instruments in the same grid is dangerous while `electric_guitar` and `acoustic_guitar` are not)
+Note that a section of the magenta pipeline (specifically nsynth_save_embeddings) sometimes truncates a couple characters from the start of filenames. generate.py should automatically catch this, however, it might "correct" files in unexpected ways if any filenames are substrings of other file names (having 'guitar' and 'acoustic_guitar' instruments in the same grid is dangerous while 'electric_guitar' and 'acoustic_guitar' is not)
 
 Audio should be saved as 16-bit integer wave files at 16000kHz. See the following soxi output for a valid input file:
 
@@ -86,7 +86,7 @@ Bit Rate       : 256k
 Sample Encoding: 16-bit Signed Integer PCM
 ```
 
-When you have selected the input audio files you wish to interpolate, they should be placed in this directory in a folder named `audio_input`. (n.b. AIF files will be converted to WAV automatically)
+When you have selected the input audio files you wish to interpolate, they should be placed in this directory in a folder named `audio_input` (n.b. AIF files will be converted to WAV automatically).
 
 
 ### 2. Update the settings file
@@ -95,15 +95,15 @@ The generation process is governed by the settings.json file. For example:
 ```
 {
 	"instruments": [["car","cleanbass", "cleanguitar", "crotales"],
-								  ["marimba", "electricpiano", "grungebass", "electrotom"],
-								  ["flute", "electrokick", "distortedguitar", "resopad"],
-								  ["rhodes", "sitar", "snare", "susvox"]],
+                  ["marimba", "electricpiano", "grungebass", "electrotom"],
+                  ["flute", "electrokick", "distortedguitar", "resopad"],
+                  ["rhodes", "sitar", "snare", "susvox"]],
 	"magenta_dir":	"~/magenta",
-	"pitches":   		[24, 28, 32, 36, 40, 44, 48, 52, 56, 60, 64, 68, 72, 76, 80, 84],
+	"pitches":      [24, 28, 32, 36, 40, 44, 48, 52, 56, 60, 64, 68, 72, 76, 80, 84],
 	"resolution": 	9,
 	"final_length": 64000,
-	"gpus": 				1,
-	"name": 				"multigrid_4"
+	"gpus":         1,
+	"name":         "multigrid_4"
 }
 ```
 
@@ -127,6 +127,6 @@ Set this number to match the number of GPUs your system is equipped with. This w
 
 ### 3. Run generate.py
 
-With all of the settings adjusted to reflect the input audio and the files named correctly in `audio_input`, generate.py can be run.
+With all of the settings adjusted to reflect the input audio and the files named correctly in 'audio_input', generate.py can be run.
 
-This should generate embeddings, interpolate them, and then generate the audio for the entire grid. The generated grid folder will be placed in `output_grids` and can then be opened in the NSynth MaxForLive device by selecting the folder in the 'Load Sounds' browser.
+This should generate embeddings, interpolate them, and then generate the audio for the entire grid. The generated grid folder will be placed in 'output_grids' and can then be opened in the NSynth MaxForLive device by selecting the folder in the 'Load Sounds' browser.

--- a/nsynth/README.md
+++ b/nsynth/README.md
@@ -98,11 +98,13 @@ The generation process is governed by the settings.json file. For example:
                   ["marimba", "electricpiano", "grungebass", "electrotom"],
                   ["flute", "electrokick", "distortedguitar", "resopad"],
                   ["rhodes", "sitar", "snare", "susvox"]],
-	"magenta_dir":	"~/magenta",
+	"checkpoint_dir":"~/magenta/magenta/models/nsynth/wavenet-ckpt",
 	"pitches":      [24, 28, 32, 36, 40, 44, 48, 52, 56, 60, 64, 68, 72, 76, 80, 84],
-	"resolution": 	9,
-	"final_length": 64000,
-	"gpus":         1,
+	"resolution": 	           9,
+	"final_length":            64000,
+	"gpus":                    1,
+	"batch_size_embeddings":   32,
+	"batch_size_generate":     256,
 	"name":         "multigrid_4"
 }
 ```
@@ -110,8 +112,8 @@ The generation process is governed by the settings.json file. For example:
 ##### instruments
 The 2 dimensional list of instruments to be interpolated. The placement of the instrument names in this grid determines where they will appear in the NSynth device. The first entry of the first list will be in the bottom left of the grid, while the last entry in the last list will be in the top right. The lists should reflect the instrument filenames, i.e. ‘guitar’ will point generate.py to all the correctly named ‘guitar_24.wav’, ‘guitar_28.wav’ files.
 
-##### magenta_dir
-This should point to the root directory of your Magenta installation. This is used to locate the WaveNet checkpoint file so should be set to the Magenta installation containing that file if you have multiple installations.
+##### checkpoint_dir
+This should point to the directory containing the WaveNet checkpoint file to use.
 
 ##### pitches
 This is a list of the different input pitches that should be interpolated by the pipeline. Notes between these pitches will be repitched versions of the nearest generated audio files.
@@ -125,8 +127,14 @@ The length in samples of the output wave files (can be calculated by multiplying
 ##### gpus
 Set this number to match the number of GPUs your system is equipped with. This will control the number of batches the processes are split into (enabling much faster processing times).
 
+##### batch_size_embeddings
+The size of batches for embedding generation. Larger batch sizes use more VRAM. Should be set as high as possible for a given GPU and sample length for maximum speed. Using a 4 second sample length a single GTX 1080 Ti with 11 GB VRAM can handle batches of about 48.
+
+##### batch_size_generate
+The size of batches for audio generation. Once again, larger batch sizes use more VRAM. A single GTX 1080 Ti with 11 GB VRAM can handle batches of about 512.
+
 ### 3. Run generate.py
 
-With all of the settings adjusted to reflect the input audio and the files named correctly in 'audio_input', generate.py can be run.
+With all of the settings adjusted to reflect the input audio and the files named correctly in 'audio_input', generate.py can be run from this directory.
 
 This should generate embeddings, interpolate them, and then generate the audio for the entire grid. The generated grid folder will be placed in 'output_grids' and can then be opened in the NSynth MaxForLive device by selecting the folder in the 'Load Sounds' browser.

--- a/nsynth/README.md
+++ b/nsynth/README.md
@@ -69,7 +69,7 @@ guitar_28.wav
 ...
 ```
 
-Note that a section of the magenta pipeline (specifically nsynth_save_embeddings) sometimes truncates a couple characters from the start of filenames. generate.py should automatically catch this, however, it might "correct" files in unexpected ways if any filenames are substrings of other file names (having 'guitar' and 'acoustic_guitar' instruments in the same grid is dangerous while 'electric_guitar' and 'acoustic_guitar' is not)
+Note that a section of the magenta pipeline (specifically nsynth_save_embeddings) sometimes truncates a couple characters from the start of filenames. generate.py should automatically catch this, however, it might "correct" files in unexpected ways if any filenames are substrings of other file names (having 'guitar' and 'acoustic_guitar' instruments in the same grid is dangerous while 'electric_guitar' and 'acoustic_guitar' is not).
 
 Audio should be saved as 16-bit integer wave files at 16000kHz. See the following soxi output for a valid input file:
 

--- a/nsynth/README.md
+++ b/nsynth/README.md
@@ -12,3 +12,121 @@ There are three main ways to use NSynth:
 
 See also the Jupyter notebook for NSynth in the [/jupyter-notebooks](/jupyter-notebooks)
 directory.
+
+## Creating samples for the MaxForLive Device
+
+By following this guide, you will be able to prepare audio samples in WAV/AIF format, process and interpolate them using NSynth, and use them with the MaxForLive NSynth device.
+
+A fast computer is required to produce audio in a reasonable amount of time; however it is possible to speed up the process by simplifying the task. The variables are:
+
+- Batch size (per process)
+- Number of interpolation combinations
+- Number of example pitches
+- Grid resolution
+
+As an example, a complex interpolation task (e.g. to produce the sounds for the default settings.json in this repository, the source audio for generating this multigrid is available [here](https://storage.googleapis.com/open-nsynth-super/audio/onss_source_audio.tar.gz)) includes 16 different instruments, a 9x9 grid resolution (between every set of 4 instruments), and 16 example pitches. This task takes around 9 hours on a GTX 1080 Ti and will generate 10000 audio files total.
+
+You will need a Unix-like PC or server with at least one CUDA-compatible GPU and magenta, sox, and lame installed.
+
+### 1. Preparing audio
+NSynth requires one-note samples for each of the desired source sounds across a range of pitches. In the default configuration, these should be 4000ms long. Optionally, you can release the note after 3000ms to leave a decay, however this is subjective, and something to experiment with.
+
+According to the default settings, these files should be created at the following MIDI notes:
+
+- 24 (C2)
+- 28 (E2)
+- 32 (G#2)
+- 36 (C3)
+- 40 (E3)
+- 44 (G#3)
+- 48 (C4)
+- 52 (E4)
+- 56 (G#4)
+- 60 (C5)
+- 64 (E5)
+- 68 (G#5)
+- 72 (C6)
+- 76 (E6)
+- 80 (G#6)
+- 84 (C7)
+
+
+For instruments that are out of range at any of these pitches, you can pitch down or up using software, or repeat the nearest ‘available’ pitch to fill in the gaps. Alternatively, for unpitched sounds like drums you can maintain a single pitch across all notes, or pitch each one manually.
+
+Changing these conditioning values can result in interesting different combinations and is one of the most interesting and powerful ways to alter the behavior of the instrument.
+
+Samples should be named using the following convention:
+
+```
+[soundname]_[pitch].wav
+```
+
+For example, the sound ‘guitar’ would be stored as:
+
+```
+guitar_24.wav
+guitar_28.wav
+...
+```
+
+Note that a section of the magenta pipeline (`nsynth_save_embeddings`) sometimes truncates a couple characters from the start of filenames. generate.py should automatically correct this, however, it might "correct" files in unexpected ways if any filenames are substrings of other file names (having `guitar` and `acoustic_guitar` instruments in the same grid is dangerous while `electric_guitar` and `acoustic_guitar` are not)
+
+Audio should be saved as 16-bit integer wave files at 16000kHz. See the following soxi output for a valid input file:
+
+```
+$ soxi guitar_24.wav
+
+Input File     : 'grungebass_24.wav'
+Channels       : 1
+Sample Rate    : 16000
+Precision      : 16-bit
+Duration       : 00:00:04.00 = 64000 samples ~ 300 CDDA sectors
+File Size      : 128k
+Bit Rate       : 256k
+Sample Encoding: 16-bit Signed Integer PCM
+```
+
+When you have selected the input audio files you wish to interpolate, they should be placed in this directory in a folder named `audio_input`. (n.b. AIF files will be converted to WAV automatically)
+
+
+### 2. Update the settings file
+
+The generation process is governed by the settings.json file. For example:
+```
+{
+	"instruments": [["car","cleanbass", "cleanguitar", "crotales"],
+								  ["marimba", "electricpiano", "grungebass", "electrotom"],
+								  ["flute", "electrokick", "distortedguitar", "resopad"],
+								  ["rhodes", "sitar", "snare", "susvox"]],
+	"magenta_dir":	"~/magenta",
+	"pitches":   		[24, 28, 32, 36, 40, 44, 48, 52, 56, 60, 64, 68, 72, 76, 80, 84],
+	"resolution": 	9,
+	"final_length": 64000,
+	"gpus": 				1,
+	"name": 				"multigrid_4"
+}
+```
+
+##### instruments
+The 2 dimensional list of instruments to be interpolated. The placement of the instrument names in this grid determines where they will appear in the NSynth device. The first entry of the first list will be in the bottom left of the grid, while the last entry in the last list will be in the top right. The lists should reflect the instrument filenames, i.e. ‘guitar’ will point generate.py to all the correctly named ‘guitar_24.wav’, ‘guitar_28.wav’ files.
+
+##### magenta_dir
+This should point to the root directory of your Magenta installation. This is used to locate the WaveNet checkpoint file so should be set to the Magenta installation containing that file if you have multiple installations.
+
+##### pitches
+This is a list of the different input pitches that should be interpolated by the pipeline. Notes between these pitches will be repitched versions of the nearest generated audio files.
+
+##### resolution
+This setting controls how many inter-instrumental interpolations are created. Higher resolutions will create closer and smoother interpolations at a cost of disk space and processing time.
+
+##### final_length
+The length in samples of the output wave files (can be calculated by multiplying the desired number of seconds by 16000).
+
+##### gpus
+Set this number to match the number of GPUs your system is equipped with. This will control the number of batches the processes are split into (enabling much faster processing times).
+
+### 3. Run generate.py
+
+With all of the settings adjusted to reflect the input audio and the files named correctly in `audio_input`, generate.py can be run.
+
+This should generate embeddings, interpolate them, and then generate the audio for the entire grid. The generated grid folder will be placed in `output_grids` and can then be opened in the NSynth MaxForLive device by selecting the folder in the 'Load Sounds' browser.

--- a/nsynth/generate.py
+++ b/nsynth/generate.py
@@ -1,0 +1,270 @@
+import json, os, sys, re, subprocess, fnmatch, time
+from os.path import basename, isfile
+from math import floor, ceil
+from multiprocessing.dummy import Pool as ThreadPool
+import librosa
+import scipy.io
+import numpy as np
+from tqdm import tqdm
+from itertools import product
+
+#	load the settings file
+settings = None
+with open('settings.json', 'r') as infile:
+    settings = json.load(infile)
+
+#	preserve the working directory path
+source_dir = os.getcwd()
+
+def compute_embeddings():
+    #   convert all aif files to wav
+    if ['aif' in f for f in os.listdir('audio_input')]:
+        for fname in os.listdir('audio_input'):
+            if 'aif' in fname:
+            	nfn = 'audio_input/'+fname.replace('aif', 'wav')
+            	subprocess.call(["sox", 'audio_input/'+fname, "-b", "16", "-r", "16000", "-c", "1", nfn])
+            	os.remove('audio_input/'+fname)
+
+    subprocess.check_call(["nsynth_save_embeddings",
+        "--checkpoint_path=%s/magenta/models/nsynth/wavenet-ckpt/model.ckpt-200000" % settings['magenta_dir'],
+        "--source_path=%s/audio_input" % source_dir,
+        "--save_path=%s/working_dir/embeddings/input" % source_dir,
+        "--batch_size=48",
+        "--sample_length=%s" % settings["final_length"]])
+
+
+def correct_truncated_names():
+    for original_name in os.listdir('audio_input'):
+    	if isfile('working_dir/embeddings/input/'+os.path.splitext(original_name)[0]+"_embeddings.npy"):
+            continue
+        else:
+            for misnomer in os.listdir('working_dir/embeddings/input'):
+                if misnomer.replace('_embeddings.npy','') in original_name:
+                    os.rename('working_dir/embeddings/input/'+misnomer,
+                              'working_dir/embeddings/input/'+os.path.splitext(original_name)[0]+"_embeddings.npy")
+                    break
+
+
+def interpolate_embeddings():
+    #	constants and rearrangement of settings vars for processing
+    pitches = settings['pitches']
+    resolution = settings['resolution']
+    final_length = settings['final_length']
+    instrument_grid = settings['instruments']
+    grid_size = len(instrument_grid[0]) - 1 - 1e-13
+
+    #   set up sub grid
+    res = (resolution - 1) * grid_size + 1
+    x, y = np.meshgrid(np.linspace(0, grid_size, res+1), np.linspace(0, grid_size, res+1))
+    x = x.reshape(-1)
+    y = y.reshape(-1)
+    xy_grid = zip(x, y)
+
+    #	cache all embeddings
+    embeddings_lookup = {}
+
+    for filename in os.listdir('working_dir/embeddings/input/'):
+    	# ignore all non-npy files
+    	if '.npy' in  filename:
+    		#	convert filename to reference key
+    		parts = basename(filename).split('_')
+    		reference = '{}_{}'.format(parts[0], parts[1])
+
+    		#	load the saved embedding
+    		embeddings_lookup[reference] = np.load("working_dir/embeddings/input/%s" % filename)
+
+    def get_embedding(instrument, pitch):
+    	reference = '{}_{}'.format(instrument, pitch)
+    	return embeddings_lookup[reference]
+
+    def get_instruments(xy):
+        uv = (int(floor(xy[0])), int(floor(xy[1])))
+        return [instrument_grid[uv[0]][uv[1]],instrument_grid[uv[0]][uv[1]+1],
+                instrument_grid[uv[0]+1][uv[1]],instrument_grid[uv[0]+1][uv[1]+1]]
+
+    def get_weights(xy):
+        uv = (int(floor(xy[0])), int(floor(xy[1])))
+        corners = np.array([[uv[0],uv[1]], [uv[0],uv[1]+1], [uv[0]+1,uv[1]], [uv[0]+1,uv[1]+1]])
+        distances = np.linalg.norm(xy - corners, axis=1)
+        distances = np.maximum(1 - distances, 0)
+        distances /= distances.sum()
+        return distances
+
+    done = set()
+
+    if not os.path.exists('working_dir/embeddings/interp'):
+        os.mkdir('working_dir/embeddings/interp')
+
+    for idx, xy in enumerate(xy_grid):
+
+        sub_grid, weights = get_instruments(xy), get_weights(xy)
+
+        for pitch in pitches:
+            embeddings = np.asarray([get_embedding(instrument, pitch) for instrument in sub_grid])
+            interp = (embeddings.T * weights).T.sum(axis=0)
+
+            name = "%s_%06d_x%.2f_y%.2f_pitch%s" % (settings['name'], idx, xy[0], xy[1], pitch)
+            np.save('working_dir/embeddings/interp/' + name + '.npy', interp.astype(np.float32))
+
+
+def batch_embeddings():
+    num_embeddings = len(os.listdir('working_dir/embeddings/interp/'))
+    batch_size = num_embeddings / settings['gpus']
+
+    if not os.path.exists('working_dir/audio'):
+        os.mkdir('working_dir/audio')
+
+    #	split the embeddings per gpu in folders
+    for i in range(0, settings['gpus']):
+    	foldername = 'working_dir/embeddings/interp/batch%i' % i
+    	if not os.path.exists(foldername):
+    		os.mkdir(foldername)
+    	output_foldername = 'working_dir/audio/batch%i' % i
+    	if not os.path.exists(output_foldername):
+    		os.mkdir(output_foldername)
+
+    #	shuffle to the folders
+    batch = 0
+    for filename in os.listdir('working_dir/embeddings/interp'):
+        if os.path.isfile('working_dir/embeddings/interp/' + filename) and not filename.startswith('.'):
+            target_folder = 'working_dir/embeddings/interp/batch%i/' % batch
+            batch += 1
+            if batch >= settings['gpus']:
+                batch = 0
+            os.rename('working_dir/embeddings/interp/' + filename, target_folder + filename)
+
+
+#	format call to nsynth_generate
+def gen_call(gpu):
+    print("Generating on GPU %i"%gpu)
+    return subprocess.call(["nsynth_generate",
+        "--checkpoint_path=%s/magenta/models/nsynth/wavenet-ckpt/model.ckpt-200000" % settings['magenta_dir'],
+        "--source_path=%s/working_dir/embeddings/interp/batch%s" % (source_dir, gpu),
+        "--save_path=%s/working_dir/audio/batch%s" % (source_dir, gpu),
+        "--sample_length=%s" % settings["final_length"],
+        "--batch_size=512",
+        "--log=WARN",
+        "--gpu_number=%s" % gpu])
+
+
+def generate_audio():
+    #	set up thread pool with a thread per gpu
+    pool = ThreadPool(settings['gpus'])
+
+    #	map calls to gpu threads
+    results = pool.map_async(gen_call, range(settings['gpus']))
+    time.sleep(5)
+    pbar = tqdm(total=sum([len(os.listdir('working_dir/embeddings/interp/batch%s'%(i))) for i in range(settings['gpus'])]))
+    pbar.set_description("Number of files for which processing has started")
+    while not results.ready():
+        num_files = sum([len(os.listdir('working_dir/audio/batch%s'%(i))) for i in range(settings['gpus'])])
+        pbar.update(num_files - pbar.n)
+        time.sleep(1)
+    pbar.close()
+    pool.close()
+    pool.join()
+
+    #	check that all threads returned successfully (exit code 0)
+    assert sum(results.get()) == 0
+
+    #	move files out of batch folders
+    if not os.path.exists('working_dir/audio/raw_wav'):
+        os.mkdir('working_dir/audio/raw_wav')
+    subprocess.call("find working_dir/audio -name \"*.wav\" | \
+                     while read f; do mv $f working_dir/audio/raw_wav/${f##*/}; done", shell=True)
+
+
+def clean_files():
+    original_path = os.path.join(source_dir, 'working_dir/audio/raw_wav/')
+    cleaned_path = os.path.join(source_dir, 'output_grids', settings['name'])
+
+    if not os.path.exists(cleaned_path):
+        os.mkdir(cleaned_path)
+
+    files = os.listdir(original_path)
+    files = [f for f in files if '.wav' in f]
+
+    for fpath in tqdm(files):
+        audio, sr = librosa.core.load(os.path.join(original_path, fpath), sr=16000)
+
+        #   remove clicks
+        d = audio[1:] - audio[:-1]
+        d_thresh = np.where(np.abs(d) > 1.0)[0]
+        clicks = [
+            c for i, c in enumerate(d_thresh[:-1])
+            if d_thresh[i] + 1 == d_thresh[i + 1]
+        ]
+        for click in clicks:
+            audio[click + 1] = (audio[click] + audio[click + 2]) / 2.0
+
+        new_fpath = fpath.replace('gen_','')
+
+        temp_file = os.path.join(cleaned_path, 'cleaned_' + new_fpath)
+        with open(temp_file, 'w') as f:
+            data_16bit = audio * 2**15
+            scipy.io.wavfile.write(f, 16000, data_16bit.astype(np.int16))
+
+        #	normalize audio level
+        cleaned_file = os.path.join(cleaned_path, new_fpath)
+        sox_cmd = "sox --norm=-12 '{}' '{}'".format(temp_file, cleaned_file)
+        os.system(sox_cmd)
+
+        #	convert to mp3
+        os.system("lame --quiet '{}'".format(cleaned_file))
+
+        #	cleanup (remove the wavs having converted to mp3)
+        os.remove(temp_file)
+        os.remove(cleaned_file)
+
+
+def generate_options_file():
+    outut_file = os.path.join(source_dir, 'output_grids', settings['name'], 'options')
+
+    instrument_grid = settings['instruments']
+    grid_size = len(instrument_grid) - 1
+
+    min_pitch                      = str(settings['pitches'][0])
+    half_steps_between_pitches     = str(settings['pitches'][1] - settings['pitches'][0])
+    pitches_per_initial_instrument = str(len(settings['pitches']))
+    num_interpolations             = str(int((settings['resolution'] - 1) * grid_size + 1))
+    num_instruments                = str(len(instrument_grid))
+    name                           = settings['name']
+    
+    with open(outut_file, 'w') as options:
+        options.write('1, ')
+        options.write(min_pitch)
+        options.write(' ')
+        options.write(half_steps_between_pitches)
+        options.write(' ')
+        options.write(pitches_per_initial_instrument)
+        options.write(' ')
+        options.write(num_interpolations)
+        options.write(' ')
+        options.write(num_interpolations)
+        options.write(' ')
+        options.write(num_instruments)
+        options.write(' ')
+        options.write(num_instruments)
+        options.write(' ')
+        options.write(name)
+        options.write(';')
+
+
+if __name__ == "__main__":
+    print("\nComputing embeddings for each instrument at each pitch...\n")
+    compute_embeddings()
+    correct_truncated_names()
+
+    print("\nInterpolating embeddings between instruments at each pitch...")
+    interpolate_embeddings()
+
+    print("\nBatchings embeddings for GPU(s)...")
+    batch_embeddings()
+
+    print("Generating audio from embeddings (this may take a while!)\n")
+    generate_audio()
+
+    print("\nCleaning up generated audio files...\n")
+    clean_files()
+
+    generate_options_file()

--- a/nsynth/generate.py
+++ b/nsynth/generate.py
@@ -1,3 +1,23 @@
+# Copyright 2017 Google Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     https://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Adapted from the Open NSynth Super audio generation pipeline found at
+# https://github.com/googlecreativelab/open-nsynth-super/tree/master/audio
+# Changes were made to ensure output audio files conform with the NSynth
+# MaxForLive device's epectations and so that the entire pipeline could be
+# run at once.
+
 import json, os, sys, re, subprocess, fnmatch, time
 from os.path import basename, isfile
 from math import floor, ceil
@@ -229,7 +249,7 @@ def generate_options_file():
     num_interpolations             = str(int((settings['resolution'] - 1) * grid_size + 1))
     num_instruments                = str(len(instrument_grid))
     name                           = settings['name']
-    
+
     with open(outut_file, 'w') as options:
         options.write('1, ')
         options.write(min_pitch)

--- a/nsynth/generate.py
+++ b/nsynth/generate.py
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 
-#     https://www.apache.org/licenses/LICENSE-2.0
+#   https://www.apache.org/licenses/LICENSE-2.0
 
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -28,263 +28,263 @@ import numpy as np
 from tqdm import tqdm
 from itertools import product
 
-#	load the settings file
+#  load the settings file
 settings = None
 with open('settings.json', 'r') as infile:
-    settings = json.load(infile)
+  settings = json.load(infile)
 
-#	preserve the working directory path
+#  preserve the working directory path
 source_dir = os.getcwd()
 
 def compute_embeddings():
-    #   convert all aif files to wav
-    if ['aif' in f for f in os.listdir('audio_input')]:
-        for fname in os.listdir('audio_input'):
-            if 'aif' in fname:
-            	nfn = 'audio_input/'+fname.replace('aif', 'wav')
-            	subprocess.call(["sox", 'audio_input/'+fname, "-b", "16", "-r", "16000", "-c", "1", nfn])
-            	os.remove('audio_input/'+fname)
+  #   convert all aif files to wav
+  if ['aif' in f for f in os.listdir('audio_input')]:
+    if not os.path.exists('aif_bkp'):
+      os.mkdir('aif_bkp')
+    for fname in os.listdir('audio_input'):
+      if 'aif' in fname:
+        nfn = 'audio_input/'+fname.replace('aif', 'wav')
+        subprocess.call(["sox", 'audio_input/'+fname, "-b", "16", "-r", "16000", "-c", "1", nfn])
+        os.rename('audio_input/'+fname, 'aif_bkp/'+fname)
 
-    subprocess.check_call(["nsynth_save_embeddings",
-        "--checkpoint_path=%s/magenta/models/nsynth/wavenet-ckpt/model.ckpt-200000" % settings['magenta_dir'],
-        "--source_path=%s/audio_input" % source_dir,
-        "--save_path=%s/working_dir/embeddings/input" % source_dir,
-        "--batch_size=48",
-        "--sample_length=%s" % settings["final_length"]])
+  subprocess.check_call(["nsynth_save_embeddings",
+    "--checkpoint_path=%s/model.ckpt-200000" % settings['checkpoint_dir'],
+    "--source_path=%s/audio_input" % source_dir,
+    "--save_path=%s/working_dir/embeddings/input" % source_dir,
+    "--batch_size=%i" % settings["batch_size_embeddings"],
+    "--sample_length=%s" % settings["final_length"]])
 
 
 def correct_truncated_names():
-    for original_name in os.listdir('audio_input'):
-    	if isfile('working_dir/embeddings/input/'+os.path.splitext(original_name)[0]+"_embeddings.npy"):
-            continue
-        else:
-            for misnomer in os.listdir('working_dir/embeddings/input'):
-                if misnomer.replace('_embeddings.npy','') in original_name:
-                    os.rename('working_dir/embeddings/input/'+misnomer,
-                              'working_dir/embeddings/input/'+os.path.splitext(original_name)[0]+"_embeddings.npy")
-                    break
+  for original_name in os.listdir('audio_input'):
+    if isfile('working_dir/embeddings/input/'+os.path.splitext(original_name)[0]+"_embeddings.npy"):
+      continue
+    else:
+      for misnomer in os.listdir('working_dir/embeddings/input'):
+        if misnomer.replace('_embeddings.npy','') in original_name:
+          os.rename('working_dir/embeddings/input/'+misnomer,
+                'working_dir/embeddings/input/'+os.path.splitext(original_name)[0]+"_embeddings.npy")
+          break
 
 
 def interpolate_embeddings():
-    #	constants and rearrangement of settings vars for processing
-    pitches = settings['pitches']
-    resolution = settings['resolution']
-    final_length = settings['final_length']
-    instrument_grid = settings['instruments']
-    grid_size = len(instrument_grid[0]) - 1 - 1e-13
+  #  constants and rearrangement of settings vars for processing
+  pitches = settings['pitches']
+  resolution = settings['resolution']
+  final_length = settings['final_length']
+  instrument_grid = settings['instruments']
+  grid_size = len(instrument_grid[0]) - 1 - 1e-13
 
-    #   set up sub grid
-    res = (resolution - 1) * grid_size + 1
-    x, y = np.meshgrid(np.linspace(0, grid_size, res+1), np.linspace(0, grid_size, res+1))
-    x = x.reshape(-1)
-    y = y.reshape(-1)
-    xy_grid = zip(x, y)
+  #  set up sub grid
+  res = (resolution - 1) * grid_size + 1
+  x, y = np.meshgrid(np.linspace(0, grid_size, res+1), np.linspace(0, grid_size, res+1))
+  x = x.reshape(-1)
+  y = y.reshape(-1)
+  xy_grid = zip(x, y)
 
-    #	cache all embeddings
-    embeddings_lookup = {}
+  #  cache all embeddings
+  embeddings_lookup = {}
 
-    for filename in os.listdir('working_dir/embeddings/input/'):
-    	# ignore all non-npy files
-    	if '.npy' in  filename:
-    		#	convert filename to reference key
-    		parts = basename(filename).split('_')
-    		reference = '{}_{}'.format(parts[0], parts[1])
+  for filename in os.listdir('working_dir/embeddings/input/'):
+    #  ignore all non-npy files
+    if '.npy' in  filename:
+      #  convert filename to reference key
+      parts = basename(filename).split('_')
+      reference = '{}_{}'.format(parts[0], parts[1])
 
-    		#	load the saved embedding
-    		embeddings_lookup[reference] = np.load("working_dir/embeddings/input/%s" % filename)
+      #  load the saved embedding
+      embeddings_lookup[reference] = np.load("working_dir/embeddings/input/%s" % filename)
 
-    def get_embedding(instrument, pitch):
-    	reference = '{}_{}'.format(instrument, pitch)
-    	return embeddings_lookup[reference]
+  def get_embedding(instrument, pitch):
+    reference = '{}_{}'.format(instrument, pitch)
+    return embeddings_lookup[reference]
 
-    def get_instruments(xy):
-        uv = (int(floor(xy[0])), int(floor(xy[1])))
-        return [instrument_grid[uv[0]][uv[1]],instrument_grid[uv[0]][uv[1]+1],
-                instrument_grid[uv[0]+1][uv[1]],instrument_grid[uv[0]+1][uv[1]+1]]
+  def get_instruments(xy):
+    uv = (int(floor(xy[0])), int(floor(xy[1])))
+    return [instrument_grid[uv[0]][uv[1]],instrument_grid[uv[0]][uv[1]+1],
+        instrument_grid[uv[0]+1][uv[1]],instrument_grid[uv[0]+1][uv[1]+1]]
 
-    def get_weights(xy):
-        uv = (int(floor(xy[0])), int(floor(xy[1])))
-        corners = np.array([[uv[0],uv[1]], [uv[0],uv[1]+1], [uv[0]+1,uv[1]], [uv[0]+1,uv[1]+1]])
-        distances = np.linalg.norm(xy - corners, axis=1)
-        distances = np.maximum(1 - distances, 0)
-        distances /= distances.sum()
-        return distances
+  def get_weights(xy):
+    uv = (int(floor(xy[0])), int(floor(xy[1])))
+    corners = np.array([[uv[0],uv[1]], [uv[0],uv[1]+1], [uv[0]+1,uv[1]], [uv[0]+1,uv[1]+1]])
+    distances = np.linalg.norm(xy - corners, axis=1)
+    distances = np.maximum(1 - distances, 0)
+    distances /= distances.sum()
+    return distances
 
-    done = set()
+  done = set()
 
-    if not os.path.exists('working_dir/embeddings/interp'):
-        os.mkdir('working_dir/embeddings/interp')
+  if not os.path.exists('working_dir/embeddings/interp'):
+    os.mkdir('working_dir/embeddings/interp')
 
-    for idx, xy in enumerate(xy_grid):
+  for idx, xy in enumerate(xy_grid):
+    sub_grid, weights = get_instruments(xy), get_weights(xy)
+    for pitch in pitches:
+      embeddings = np.asarray([get_embedding(instrument, pitch) for instrument in sub_grid])
+      interp = (embeddings.T * weights).T.sum(axis=0)
 
-        sub_grid, weights = get_instruments(xy), get_weights(xy)
-
-        for pitch in pitches:
-            embeddings = np.asarray([get_embedding(instrument, pitch) for instrument in sub_grid])
-            interp = (embeddings.T * weights).T.sum(axis=0)
-
-            name = "%s_%06d_x%.2f_y%.2f_pitch%s" % (settings['name'], idx, xy[0], xy[1], pitch)
-            np.save('working_dir/embeddings/interp/' + name + '.npy', interp.astype(np.float32))
+      name = "%s_%06d_x%.2f_y%.2f_pitch%s" % (settings['name'], idx, xy[0], xy[1], pitch)
+      np.save('working_dir/embeddings/interp/' + name + '.npy', interp.astype(np.float32))
 
 
 def batch_embeddings():
-    num_embeddings = len(os.listdir('working_dir/embeddings/interp/'))
-    batch_size = num_embeddings / settings['gpus']
+  num_embeddings = len(os.listdir('working_dir/embeddings/interp/'))
+  batch_size = num_embeddings / settings['gpus']
 
-    if not os.path.exists('working_dir/audio'):
-        os.mkdir('working_dir/audio')
+  if not os.path.exists('working_dir/audio'):
+    os.mkdir('working_dir/audio')
 
-    #	split the embeddings per gpu in folders
-    for i in range(0, settings['gpus']):
-    	foldername = 'working_dir/embeddings/interp/batch%i' % i
-    	if not os.path.exists(foldername):
-    		os.mkdir(foldername)
-    	output_foldername = 'working_dir/audio/batch%i' % i
-    	if not os.path.exists(output_foldername):
-    		os.mkdir(output_foldername)
+  #  split the embeddings per gpu in folders
+  for i in range(0, settings['gpus']):
+    foldername = 'working_dir/embeddings/interp/batch%i' % i
+    if not os.path.exists(foldername):
+      os.mkdir(foldername)
+    output_foldername = 'working_dir/audio/batch%i' % i
+    if not os.path.exists(output_foldername):
+      os.mkdir(output_foldername)
 
-    #	shuffle to the folders
-    batch = 0
-    for filename in os.listdir('working_dir/embeddings/interp'):
-        if os.path.isfile('working_dir/embeddings/interp/' + filename) and not filename.startswith('.'):
-            target_folder = 'working_dir/embeddings/interp/batch%i/' % batch
-            batch += 1
-            if batch >= settings['gpus']:
-                batch = 0
-            os.rename('working_dir/embeddings/interp/' + filename, target_folder + filename)
+  #  shuffle to the folders
+  batch = 0
+  for filename in os.listdir('working_dir/embeddings/interp'):
+    if os.path.isfile('working_dir/embeddings/interp/' + filename) and not filename.startswith('.'):
+      target_folder = 'working_dir/embeddings/interp/batch%i/' % batch
+      batch += 1
+      if batch >= settings['gpus']:
+        batch = 0
+      os.rename('working_dir/embeddings/interp/' + filename, target_folder + filename)
 
 
-#	format call to nsynth_generate
+#  format call to nsynth_generate
 def gen_call(gpu):
-    print("Generating on GPU %i"%gpu)
-    return subprocess.call(["nsynth_generate",
-        "--checkpoint_path=%s/magenta/models/nsynth/wavenet-ckpt/model.ckpt-200000" % settings['magenta_dir'],
-        "--source_path=%s/working_dir/embeddings/interp/batch%s" % (source_dir, gpu),
-        "--save_path=%s/working_dir/audio/batch%s" % (source_dir, gpu),
-        "--sample_length=%s" % settings["final_length"],
-        "--batch_size=512",
-        "--log=WARN",
-        "--gpu_number=%s" % gpu])
+  print("Generating on GPU %i"%gpu)
+  return subprocess.call(["nsynth_generate",
+    "--checkpoint_path=%s/model.ckpt-200000" % settings['checkpoint_dir'],
+    "--source_path=%s/working_dir/embeddings/interp/batch%s" % (source_dir, gpu),
+    "--save_path=%s/working_dir/audio/batch%s" % (source_dir, gpu),
+    "--sample_length=%s" % settings["final_length"],
+    "--batch_size=%i" % settings["batch_size_generate"],
+    "--log=WARN",
+    "--gpu_number=%s" % gpu])
 
 
 def generate_audio():
-    #	set up thread pool with a thread per gpu
-    pool = ThreadPool(settings['gpus'])
+  #  set up thread pool with a thread per gpu
+  pool = ThreadPool(settings['gpus'])
 
-    #	map calls to gpu threads
-    results = pool.map_async(gen_call, range(settings['gpus']))
-    time.sleep(5)
-    pbar = tqdm(total=sum([len(os.listdir('working_dir/embeddings/interp/batch%s'%(i))) for i in range(settings['gpus'])]))
-    pbar.set_description("Number of files for which processing has started")
-    while not results.ready():
-        num_files = sum([len(os.listdir('working_dir/audio/batch%s'%(i))) for i in range(settings['gpus'])])
-        pbar.update(num_files - pbar.n)
-        time.sleep(1)
-    pbar.close()
-    pool.close()
-    pool.join()
+  #  map calls to gpu threads
+  results = pool.map_async(gen_call, range(settings['gpus']))
+  time.sleep(5)
+  pbar = tqdm(total=sum([len(os.listdir('working_dir/embeddings/interp/batch%s'%(i))) for i in range(settings['gpus'])]))
+  pbar.set_description("Number of files for which processing has started")
+  while not results.ready():
+    num_files = sum([len(os.listdir('working_dir/audio/batch%s'%(i))) for i in range(settings['gpus'])])
+    pbar.update(num_files - pbar.n)
+    time.sleep(1)
+  pbar.close()
+  pool.close()
+  pool.join()
 
-    #	check that all threads returned successfully (exit code 0)
-    assert sum(results.get()) == 0
+  #  check that all threads returned successfully (exit code 0)
+  assert sum(results.get()) == 0
 
-    #	move files out of batch folders
-    if not os.path.exists('working_dir/audio/raw_wav'):
-        os.mkdir('working_dir/audio/raw_wav')
-    subprocess.call("find working_dir/audio -name \"*.wav\" | \
-                     while read f; do mv $f working_dir/audio/raw_wav/${f##*/}; done", shell=True)
+  #  move files out of batch folders
+  if not os.path.exists('working_dir/audio/raw_wav'):
+    os.mkdir('working_dir/audio/raw_wav')
+  subprocess.call("find working_dir/audio -name \"*.wav\" | \
+                   while read f; do mv $f working_dir/audio/raw_wav/${f##*/}; done", shell=True)
 
 
 def clean_files():
-    original_path = os.path.join(source_dir, 'working_dir/audio/raw_wav/')
-    cleaned_path = os.path.join(source_dir, 'output_grids', settings['name'])
+  original_path = os.path.join(source_dir, 'working_dir/audio/raw_wav/')
+  cleaned_path = os.path.join(source_dir, 'output_grids', settings['name'])
 
-    if not os.path.exists(cleaned_path):
-        os.mkdir(cleaned_path)
+  if not os.path.exists(cleaned_path):
+    os.mkdir(cleaned_path)
 
-    files = os.listdir(original_path)
-    files = [f for f in files if '.wav' in f]
+  files = os.listdir(original_path)
+  files = [f for f in files if '.wav' in f]
 
-    for fpath in tqdm(files):
-        audio, sr = librosa.core.load(os.path.join(original_path, fpath), sr=16000)
+  for fpath in tqdm(files):
+    audio, sr = librosa.core.load(os.path.join(original_path, fpath), sr=16000)
 
-        #   remove clicks
-        d = audio[1:] - audio[:-1]
-        d_thresh = np.where(np.abs(d) > 1.0)[0]
-        clicks = [
-            c for i, c in enumerate(d_thresh[:-1])
-            if d_thresh[i] + 1 == d_thresh[i + 1]
-        ]
-        for click in clicks:
-            audio[click + 1] = (audio[click] + audio[click + 2]) / 2.0
+    #   remove clicks
+    d = audio[1:] - audio[:-1]
+    d_thresh = np.where(np.abs(d) > 1.0)[0]
+    clicks = [
+      c for i, c in enumerate(d_thresh[:-1])
+      if d_thresh[i] + 1 == d_thresh[i + 1]
+    ]
+    for click in clicks:
+      audio[click + 1] = (audio[click] + audio[click + 2]) / 2.0
 
-        new_fpath = fpath.replace('gen_','')
+    new_fpath = fpath.replace('gen_','')
 
-        temp_file = os.path.join(cleaned_path, 'cleaned_' + new_fpath)
-        with open(temp_file, 'w') as f:
-            data_16bit = audio * 2**15
-            scipy.io.wavfile.write(f, 16000, data_16bit.astype(np.int16))
+    temp_file = os.path.join(cleaned_path, 'cleaned_' + new_fpath)
+    with open(temp_file, 'w') as f:
+      data_16bit = audio * 2**15
+      scipy.io.wavfile.write(f, 16000, data_16bit.astype(np.int16))
 
-        #	normalize audio level
-        cleaned_file = os.path.join(cleaned_path, new_fpath)
-        sox_cmd = "sox --norm=-12 '{}' '{}'".format(temp_file, cleaned_file)
-        os.system(sox_cmd)
+    #  normalize audio level
+    cleaned_file = os.path.join(cleaned_path, new_fpath)
+    sox_cmd = "sox --norm=-12 '{}' '{}'".format(temp_file, cleaned_file)
+    os.system(sox_cmd)
 
-        #	convert to mp3
-        os.system("lame --quiet '{}'".format(cleaned_file))
+    #  convert to mp3
+    os.system("lame --quiet '{}'".format(cleaned_file))
 
-        #	cleanup (remove the wavs having converted to mp3)
-        os.remove(temp_file)
-        os.remove(cleaned_file)
+    #  cleanup (remove the wavs having converted to mp3)
+    os.remove(temp_file)
+    os.remove(cleaned_file)
 
 
 def generate_options_file():
-    outut_file = os.path.join(source_dir, 'output_grids', settings['name'], 'options')
+  outut_file = os.path.join(source_dir, 'output_grids', settings['name'], 'options')
 
-    instrument_grid = settings['instruments']
-    grid_size = len(instrument_grid) - 1
+  instrument_grid = settings['instruments']
+  grid_size = len(instrument_grid) - 1
 
-    min_pitch                      = str(settings['pitches'][0])
-    half_steps_between_pitches     = str(settings['pitches'][1] - settings['pitches'][0])
-    pitches_per_initial_instrument = str(len(settings['pitches']))
-    num_interpolations             = str(int((settings['resolution'] - 1) * grid_size + 1))
-    num_instruments                = str(len(instrument_grid))
-    name                           = settings['name']
+  min_pitch                      = str(settings['pitches'][0])
+  half_steps_between_pitches     = str(settings['pitches'][1] - settings['pitches'][0])
+  pitches_per_initial_instrument = str(len(settings['pitches']))
+  num_interpolations             = str(int((settings['resolution'] - 1) * grid_size + 1))
+  num_instruments                = str(len(instrument_grid))
+  name                           = settings['name']
 
-    with open(outut_file, 'w') as options:
-        options.write('1, ')
-        options.write(min_pitch)
-        options.write(' ')
-        options.write(half_steps_between_pitches)
-        options.write(' ')
-        options.write(pitches_per_initial_instrument)
-        options.write(' ')
-        options.write(num_interpolations)
-        options.write(' ')
-        options.write(num_interpolations)
-        options.write(' ')
-        options.write(num_instruments)
-        options.write(' ')
-        options.write(num_instruments)
-        options.write(' ')
-        options.write(name)
-        options.write(';')
+  with open(outut_file, 'w') as options:
+    options.write('1, ')
+    options.write(min_pitch)
+    options.write(' ')
+    options.write(half_steps_between_pitches)
+    options.write(' ')
+    options.write(pitches_per_initial_instrument)
+    options.write(' ')
+    options.write(num_interpolations)
+    options.write(' ')
+    options.write(num_interpolations)
+    options.write(' ')
+    options.write(num_instruments)
+    options.write(' ')
+    options.write(num_instruments)
+    options.write(' ')
+    options.write(name)
+    options.write(';')
 
 
 if __name__ == "__main__":
-    print("\nComputing embeddings for each instrument at each pitch...\n")
-    compute_embeddings()
-    correct_truncated_names()
+  print("\nComputing embeddings for each instrument at each pitch...\n")
+  compute_embeddings()
+  correct_truncated_names()
 
-    print("\nInterpolating embeddings between instruments at each pitch...")
-    interpolate_embeddings()
+  print("\nInterpolating embeddings between instruments at each pitch...")
+  interpolate_embeddings()
 
-    print("\nBatchings embeddings for GPU(s)...")
-    batch_embeddings()
+  print("\nBatchings embeddings for GPU(s)...")
+  batch_embeddings()
 
-    print("Generating audio from embeddings (this may take a while!)\n")
-    generate_audio()
+  print("Generating audio from embeddings (this may take a while!)\n")
+  generate_audio()
 
-    print("\nCleaning up generated audio files...\n")
-    clean_files()
+  print("\nCleaning up generated audio files...\n")
+  clean_files()
 
-    generate_options_file()
+  generate_options_file()

--- a/nsynth/settings.json
+++ b/nsynth/settings.json
@@ -1,10 +1,12 @@
 {
-	"instruments": [["applymoisterizer", "init"],
-									["methlab", "nhf"]],
+	"instruments": [["car","cleanbass", "cleanguitar", "crotales"],
+								  ["marimba", "electricpiano", "grungebass", "electrotom"],
+								  ["flute", "electrokick", "distortedguitar", "resopad"],
+								  ["rhodes", "sitar", "snare", "susvox"]],
 	"magenta_dir":	"~/magenta",
-	"pitches":   		[24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35],
+	"pitches":      [24, 28, 32, 36, 40, 44, 48, 52, 56, 60, 64, 68, 72, 76, 80, 84],
 	"resolution": 	9,
-	"final_length": 48000,
-	"gpus": 				1,
-	"name": 				"bass_grid_1"
+	"final_length": 64000,
+	"gpus":         1,
+	"name":         "multigrid_4"
 }

--- a/nsynth/settings.json
+++ b/nsynth/settings.json
@@ -3,10 +3,12 @@
 								  ["marimba", "electricpiano", "grungebass", "electrotom"],
 								  ["flute", "electrokick", "distortedguitar", "resopad"],
 								  ["rhodes", "sitar", "snare", "susvox"]],
-	"magenta_dir":	"~/magenta",
+	"checkpoint_dir":"~/magenta/magenta/models/nsynth/wavenet-ckpt",
 	"pitches":      [24, 28, 32, 36, 40, 44, 48, 52, 56, 60, 64, 68, 72, 76, 80, 84],
-	"resolution": 	9,
-	"final_length": 64000,
-	"gpus":         1,
+	"resolution": 	           9,
+	"final_length":            64000,
+	"gpus":                    1,
+	"batch_size_embeddings":   32,
+	"batch_size_generate":     256,
 	"name":         "multigrid_4"
 }

--- a/nsynth/settings.json
+++ b/nsynth/settings.json
@@ -1,12 +1,10 @@
 {
-	"instruments": [["car","cleanbass", "cleanguitar", "crotales"],
-								  ["marimba", "electricpiano", "grungebass", "electrotom"],
-								  ["flute", "electrokick", "distortedguitar", "resopad"],
-								  ["rhodes", "sitar", "snare", "susvox"]],
-	"magenta_dir":	"~/Scripts/magenta",
-	"pitches":   		[24, 28, 32, 36, 40, 44, 48, 52, 56, 60, 64, 68, 72, 76, 80, 84],
+	"instruments": [["applymoisterizer", "init"],
+									["methlab", "nhf"]],
+	"magenta_dir":	"~/magenta",
+	"pitches":   		[24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35],
 	"resolution": 	9,
-	"final_length": 64000,
+	"final_length": 48000,
 	"gpus": 				1,
-	"name": 				"multigrid_4"
+	"name": 				"bass_grid_1"
 }

--- a/nsynth/settings.json
+++ b/nsynth/settings.json
@@ -1,0 +1,12 @@
+{
+	"instruments": [["car","cleanbass", "cleanguitar", "crotales"],
+								  ["marimba", "electricpiano", "grungebass", "electrotom"],
+								  ["flute", "electrokick", "distortedguitar", "resopad"],
+								  ["rhodes", "sitar", "snare", "susvox"]],
+	"magenta_dir":	"~/Scripts/magenta",
+	"pitches":   		[24, 28, 32, 36, 40, 44, 48, 52, 56, 60, 64, 68, 72, 76, 80, 84],
+	"resolution": 	9,
+	"final_length": 64000,
+	"gpus": 				1,
+	"name": 				"multigrid_4"
+}

--- a/nsynth/settings.json
+++ b/nsynth/settings.json
@@ -1,14 +1,14 @@
 {
-	"instruments": [["car","cleanbass", "cleanguitar", "crotales"],
-								  ["marimba", "electricpiano", "grungebass", "electrotom"],
-								  ["flute", "electrokick", "distortedguitar", "resopad"],
-								  ["rhodes", "sitar", "snare", "susvox"]],
-	"checkpoint_dir":"~/magenta/magenta/models/nsynth/wavenet-ckpt",
-	"pitches":      [24, 28, 32, 36, 40, 44, 48, 52, 56, 60, 64, 68, 72, 76, 80, 84],
-	"resolution": 	           9,
-	"final_length":            64000,
-	"gpus":                    1,
-	"batch_size_embeddings":   32,
-	"batch_size_generate":     256,
-	"name":         "multigrid_4"
+    "instruments": [["car","cleanbass", "cleanguitar", "crotales"],
+                    ["marimba", "electricpiano", "grungebass", "electrotom"],
+                    ["flute", "electrokick", "distortedguitar", "resopad"],
+                    ["rhodes", "sitar", "snare", "susvox"]],
+    "checkpoint_dir":"~/magenta/magenta/models/nsynth/wavenet-ckpt",
+    "pitches":      [24, 28, 32, 36, 40, 44, 48, 52, 56, 60, 64, 68, 72, 76, 80, 84],
+    "resolution":              9,
+    "final_length":            64000,
+    "gpus":                    1,
+    "batch_size_embeddings":   32,
+    "batch_size_generate":     256,
+    "name":         "multigrid_4"
 }


### PR DESCRIPTION
Hello,

I've adapted the [Open NSynth Audio generation pipeline](https://github.com/googlecreativelab/open-nsynth-super/tree/master/audio) to generate grids/multigrids that can be used with the NSynth MaxForLive device.

I haven't been able to test it on multiple GPUs (I've only got 1) or with python3 (recompiling CUDA enabled tensorflow on macOS is quite a lot of work...), but I'm fairly sure they should work.

I also wasn't sure how exactly the Apache 2.0 license works in this case, so I've just copied the license statement that was at the top of the files in the repository linked above. Is the short statement at the top of generate.py about the changes made sufficient?

I've uploaded an example multigrid, generated with the included default settings, [here](https://drive.google.com/open?id=1Z6SqLh_-iha5C4WyEn_vg7cIDaUZyEXs).